### PR TITLE
Avoid using nixpkgs in overlay

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
     {
       overlay = final: prev: import ./default.nix {
         inherit (prev.stdenv.hostPlatform) system;
-        poetry2nix = (poetry2nix.overlay prev final).poetry2nix;
+        poetry2nix = (poetry2nix.overlay final prev).poetry2nix;
         pkgs = prev;
         rev = if (self ? rev) then self.rev else "dirty";
       };

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,8 @@
       overlay = final: prev: import ./default.nix {
         inherit (prev.stdenv.hostPlatform) system;
         poetry2nix = (poetry2nix.overlay final prev).poetry2nix;
-        pkgs = prev;
+        # FIXME: using `prev` here results in a glibc rebuild on every Python deps change
+        pkgs = final;
         rev = if (self ? rev) then self.rev else "dirty";
       };
     } // (flake-utils.lib.eachSystem [ "aarch64-linux" "i686-linux" "x86_64-linux" ] (system:


### PR DESCRIPTION
This is just an idea to remove the dependency on `nixpkgs` and maybe solve the issues with `glibc` mentioned in #20  .

I didn't encounter any issues so far, but I don't have a lot of experience with this so maybe there are other issues.