### PR TITLE
Improve user friendliness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           fi
 
       - name: CI
-        run: nix flake check
+        run: nix flake check --print-build-logs
 
       - name: Export Nix store cache
         run: nix-store --export $(find /nix/store -maxdepth 1 -name '*-*') > /tmp/nix-cache
@@ -73,7 +73,7 @@ jobs:
 
       - name: CI
         # We are running all linters in x86_64 already, no need to rerun them here
-        run: nix build --option system aarch64-linux
+        run: nix build --print-build-logs --option system aarch64-linux
 
       - name: Export Nix store cache
         run: nix-store --export $(find /nix/store -maxdepth 1 -name '*-*') > /tmp/nix-cache

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -42,7 +42,7 @@ jobs:
           nix flake update --commit-lock-file
 
       - name: CI
-        run: nix flake check
+        run: nix flake check --print-build-logs
 
       - name: Export Nix store cache
         run: nix-store --export $(find /nix/store -maxdepth 1 -name '*-*') > /tmp/nix-cache

--- a/checks.nix
+++ b/checks.nix
@@ -3,7 +3,7 @@
 , rev ? "ci"
 }:
 
-rec {
+{
   nix-alien-ci = import ./nix-alien.nix {
     inherit pkgs poetry2nix rev;
     ci = true;
@@ -19,19 +19,12 @@ rec {
     inherit pkgs;
   };
 
-  check-format-nix = pkgs.stdenv.mkDerivation {
-    name = "check-format-nix";
-    src = ./.;
-    nativeBuildInputs = [ pkgs.nixpkgs-fmt ];
-
-    dontConfigure = true;
-    dontBuild = true;
-    doCheck = true;
-
-    installPhase = "touch $out";
-
-    checkPhase = ''
-      nixpkgs-fmt --check .
-    '';
-  };
+  check-format-nix = pkgs.runCommand "check-format-nix"
+    {
+      src = ./.;
+      nativeBuildInputs = [ pkgs.nixpkgs-fmt ];
+    } ''
+    touch $out
+    nixpkgs-fmt --check $src
+  '';
 }

--- a/checks.nix
+++ b/checks.nix
@@ -1,0 +1,37 @@
+{ pkgs ? (import ./compat.nix).pkgs
+, poetry2nix ? (import ./compat.nix).poetry2nix
+, rev ? "ci"
+}:
+
+rec {
+  nix-alien-ci = import ./nix-alien.nix {
+    inherit pkgs poetry2nix rev;
+    ci = true;
+  };
+
+  nix-alien-ci-py39 = import ./nix-alien.nix {
+    inherit pkgs poetry2nix rev;
+    ci = true;
+    python = pkgs.python39;
+  };
+
+  nix-index-update-ci = import ./nix-index-update.nix {
+    inherit pkgs;
+  };
+
+  check-format-nix = pkgs.stdenv.mkDerivation {
+    name = "check-format-nix";
+    src = ./.;
+    nativeBuildInputs = [ pkgs.nixpkgs-fmt ];
+
+    dontConfigure = true;
+    dontBuild = true;
+    doCheck = true;
+
+    installPhase = "touch $out";
+
+    checkPhase = ''
+      nixpkgs-fmt --check .
+    '';
+  };
+}

--- a/default.nix
+++ b/default.nix
@@ -11,20 +11,4 @@
   nix-index-update = import ./nix-index-update.nix {
     inherit pkgs;
   };
-
-  check-format-nix = pkgs.stdenv.mkDerivation {
-    name = "check-format-nix";
-    src = ./.;
-    nativeBuildInputs = [ pkgs.nixpkgs-fmt ];
-
-    dontConfigure = true;
-    dontBuild = true;
-    doCheck = true;
-
-    installPhase = "touch $out";
-
-    checkPhase = ''
-      nixpkgs-fmt --check .
-    '';
-  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -33,12 +33,9 @@
           default = self.outputs.packages.${system}.nix-alien;
         };
 
-        checks = {
-          nix-alien-ci = pkgs.nix-alien.override { ci = true; };
-          nix-alien-ci-py39 = pkgs.nix-alien.override { ci = true; python = pkgs.python39; };
-          nix-alien-ci-py38 = pkgs.nix-alien.override { ci = true; python = pkgs.python38; };
-          nix-index-update-ci = pkgs.nix-index-update;
-          check-format-nix = pkgs.check-format-nix;
+        checks = import ./checks.nix {
+          inherit pkgs;
+          inherit (pkgs) poetry2nix;
         };
 
         apps =

--- a/nix_alien/helpers.py
+++ b/nix_alien/helpers.py
@@ -1,7 +1,8 @@
 import os
-from typing import Callable, Optional
 import uuid
+from functools import partial
 from pathlib import Path
+from typing import Callable, Optional
 
 UUID_NAMESPACE = uuid.UUID("f318d4a6-dd46-47ce-995d-e95c17cadcc0")
 
@@ -32,4 +33,4 @@ def get_print(silent: bool = False) -> Callable[..., None]:
     if silent:
         return lambda *_, **__: None
     else:
-        return print
+        return partial(print, "[nix-alien]")

--- a/nix_alien/libs.py
+++ b/nix_alien/libs.py
@@ -1,5 +1,6 @@
 import argparse
 import json
+import os
 import subprocess
 import sys
 from shlex import join
@@ -18,7 +19,14 @@ fzf = FzfPrompt()
 
 def find_lib_candidates(basename: str) -> list[str]:
     result = subprocess.run(
-        ["nix-locate", "--minimal", "--whole-name", "--top-level", basename],
+        [
+            "nix-locate",
+            "--minimal",
+            "--at-root",
+            "--whole-name",
+            "--top-level",
+            os.path.join("/lib", basename),
+        ],
         check=True,
         text=True,
         stdout=subprocess.PIPE,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 include = ["nix_alien/*.nix", "nix_alien/version"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 # TODO: go back to version once a new release is cut
 pylddwrap = { git = "https://github.com/Parquery/pylddwrap.git", rev = "4022994d5557a421ec344a074c53ba58a0241e43" }
 pyfzf = "^0.3.1"

--- a/tests/test_fhs_env.py
+++ b/tests/test_fhs_env.py
@@ -114,7 +114,7 @@ def test_main_wo_args(
     assert (
         err
         == f"""\
-File '{default_nix}' created successfuly!
+[nix-alien] File '{default_nix}' created successfuly!
 """
     )
 
@@ -178,7 +178,7 @@ def test_main_with_flake(mock_find_libs, mock_os, tmp_path, capsys):
     assert (
         err
         == f"""\
-File '{flake_nix}' created successfuly!
+[nix-alien] File '{flake_nix}' created successfuly!
 """
     )
 

--- a/tests/test_libs.py
+++ b/tests/test_libs.py
@@ -54,10 +54,10 @@ def test_find_libs_when_no_candidates_found(
     assert (
         err
         == """\
-No candidate found for 'libfoo.so'
-Selected candidate for 'libfoo.so': None
-No candidate found for 'libbar.so'
-Selected candidate for 'libbar.so': None
+[nix-alien] No candidate found for 'libfoo.so'
+[nix-alien] Selected candidate for 'libfoo.so': None
+[nix-alien] No candidate found for 'libbar.so'
+[nix-alien] Selected candidate for 'libbar.so': None
 """
     )
 
@@ -88,9 +88,9 @@ def test_find_libs_when_one_candidate_found(
     assert (
         err
         == """\
-Selected candidate for 'libfoo.so': foo.out
-Selected candidate for 'libbar.so': foo.out
-Selected candidate for 'libquux.so': foo.out
+[nix-alien] Selected candidate for 'libfoo.so': foo.out
+[nix-alien] Selected candidate for 'libbar.so': foo.out
+[nix-alien] Selected candidate for 'libquux.so': foo.out
 """
     )
 
@@ -157,8 +157,8 @@ def test_main_wo_args(mock_subprocess, mock_list_dependencies, capsys):
     assert (
         err
         == """\
-Selected candidate for 'libfoo.so': foo.out
-Selected candidate for 'libbar.so': foo.out
+[nix-alien] Selected candidate for 'libfoo.so': foo.out
+[nix-alien] Selected candidate for 'libbar.so': foo.out
 """
     )
 

--- a/tests/test_nix_ld.py
+++ b/tests/test_nix_ld.py
@@ -118,7 +118,7 @@ def test_main_wo_args(
     assert (
         err
         == f"""\
-File '{default_nix}' created successfuly!
+[nix-alien] File '{default_nix}' created successfuly!
 """
     )
 
@@ -182,7 +182,7 @@ def test_main_with_flake(mock_find_libs, mock_os, tmp_path, capsys):
     assert (
         err
         == f"""\
-File '{flake_nix}' created successfuly!
+[nix-alien] File '{flake_nix}' created successfuly!
 """
     )
 


### PR DESCRIPTION
- Only locate libraries in `$out/lib`. This should reduce the amount of false positive packages a lot, improving the situation described in #15 (but of course not fixing the issue itself, since if the package itself is not available there is nothing we can do)
- Add `[nix-alien]` prefix before all message outputs. Should make it easier to differentiate between what is the program being executed printing and what nix-alien itself is printing