### PR TITLE
Use nix-index-with-db so the program is standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,9 @@ $ nix-alien-find-libs myapp  # Lists all libs needed for the binary
 
 ## Usage
 
-Assuming you have `nix-alien` and `nix-index-update` installed, start by
-running:
-
-```console
-$ nix-index-update
-```
-
-This will avoid the slow startup of `nix-locate` by downloading it from a
-pre-computed index from
-[`nix-index-database`](https://github.com/Mic92/nix-index-database). You can
-also run `nix-index` command to compute the index locally (this will take a
-while).
-
-Afterwards, start by running:
+`nix-index` uses `nix-index-with-db` from
+[`nix-index-database`](https://github.com/Mic92/nix-index-database), so you
+don't need to do any setup. Just run:
 
 ```console
 $ nix-alien ~/myapp
@@ -123,7 +112,6 @@ $ git clone https://github.com/thiagokokada/nix-alien && cd nix-alien
 $ $(nix-build nix-alien.nix --no-out-link)/bin/nix-alien ~/myapp
 $ $(nix-build nix-alien.nix --no-out-link)/bin/nix-alien-ld ~/myapp
 $ $(nix-build nix-alien.nix --no-out-link)/bin/nix-alien-find-libs ~/myapp
-$ $(nix-build nix-index-update.nix --no-out-link)/bin/nix-index-update
 ```
 
 ### Usage without installing with Flakes
@@ -136,7 +124,6 @@ experimental Flakes support](https://nixos.wiki/wiki/Flakes#Enable_flakes).
 $ nix run "github:thiagokokada/nix-alien#nix-alien" -- ~/myapp
 $ nix run "github:thiagokokada/nix-alien#nix-alien-ld" -- ~/myapp
 $ nix run "github:thiagokokada/nix-alien#nix-alien-find-libs" -- ~/myapp
-$ nix run "github:thiagokokada/nix-alien#nix-index-update"
 ```
 
 ## NixOS Installation
@@ -154,8 +141,6 @@ in
 {
   environment.systemPackages = with nix-alien-pkgs; [
     nix-alien
-    nix-index-update
-    pkgs.nix-index # not necessary, but recommended
   ];
 
   # Optional, but this is needed for `nix-alien-ld` command
@@ -186,8 +171,6 @@ setup to install `nix-alien` on system `PATH`:
           ({ self, system, ... }: {
             environment.systemPackages = with pkgs; with self.inputs.nix-alien.packages.${system}; [
               nix-alien
-              nix-index # not necessary, but recommended
-              nix-index-update
             ];
             # Optional, needed for `nix-alien-ld`
             programs.nix-ld.enable = true;
@@ -224,8 +207,6 @@ cause issues.
             ];
             environment.systemPackages = with pkgs; [
               nix-alien
-              nix-index # not necessary, but recommended
-              nix-index-update
             ];
             # Optional, needed for `nix-alien-ld`
             programs.nix-ld.enable = true;
@@ -278,11 +259,6 @@ To solve possible conflicts, human intervation is needed, but thanks to
 [`fzf`](https://github.com/junegunn/fzf) and
 [`pyfzf`](https://github.com/nk412/pyfzf) this is made easy by
 showing an interactive list.
-
-To be able to use `nix-locate`, first, the index has to be build. This is done
-by running `nix-index` and waiting 10-15 minutes. To speed-up this process, this
-repo also includes `nix-index-update` script, that downloads the index from
-[`nix-index-database`](https://github.com/Mic92/nix-index-database).
 
 ## Credits
 

--- a/default.nix
+++ b/default.nix
@@ -18,5 +18,6 @@ in
     nix-index = self.inputs.nix-index-database.packages.${pkgs.system}.nix-index-with-db;
   };
 
+  # For backwards compat, may be removed in the future
   nix-index-update = pkgs.callPackage ./nix-index-update.nix { };
 }

--- a/default.nix
+++ b/default.nix
@@ -13,7 +13,10 @@ let
     else "0.1.0+unknown";
 in
 {
-  nix-alien = pkgs.callPackage ./nix-alien.nix { inherit rev; };
+  nix-alien = pkgs.callPackage ./nix-alien.nix {
+    inherit rev;
+    nix-index = self.inputs.nix-index-database.packages.${pkgs.system}.nix-index-with-db;
+  };
 
   nix-index-update = pkgs.callPackage ./nix-index-update.nix { };
 }

--- a/flake.lock
+++ b/flake.lock
@@ -15,6 +15,26 @@
         "type": "github"
       }
     },
+    "nix-index-database": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1675567746,
+        "narHash": "sha256-huugg+7ok2VjmoLhkT+mAcw6iVK+hOqrYV0jMMD4EpQ=",
+        "owner": "Mic92",
+        "repo": "nix-index-database",
+        "rev": "3880fa89727c622ae4674a2b6169c81112b43cf4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "nix-index-database",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1675062963,
@@ -34,6 +54,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "nix-index-database": "nix-index-database",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,16 @@
 {
   description = "nix-alien";
 
-  inputs.flake-utils.url = "github:numtide/flake-utils";
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nix-index-database = {
+      url = "github:Mic92/nix-index-database";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils, ... }:
     {
       overlays.default = final: prev: import ./overlay.nix { inherit self final prev; };
 

--- a/nix-alien.nix
+++ b/nix-alien.nix
@@ -1,13 +1,13 @@
 { lib
-, callPackage
-, python3
 , fzf
+, nix-index
+, python3
 , rev ? null
 , dev ? false
 , ci ? false
 }:
 
-assert dev -> (ci == false);
+assert dev -> !ci;
 let
   version = if (rev != null) then rev else "dev";
   deps = with builtins;
@@ -23,6 +23,7 @@ python3.pkgs.buildPythonApplication {
   src = ./.;
 
   propagatedBuildInputs = with python3.pkgs; [
+    nix-index
     setuptools
   ] ++ (lib.attrVals deps python3.pkgs);
 

--- a/shell.nix
+++ b/shell.nix
@@ -15,7 +15,6 @@ python-with-packages.env.overrideAttrs (old: {
   buildInputs = with pkgs; [
     fzf
     glibc.bin
-    nix-index
     nixpkgs-fmt
   ];
 })


### PR DESCRIPTION
After this PR is merged you won't need to run `nix-index-update` manually anymore, or even have `nix-index` in your `PATH`.

Instead, the database will be provided by the `nix-index-with-db` wrapper provided in https://github.com/Mic92/nix-index-database. This already includes an up-to-date database so the program should just works.

You can still manually override the `nix-index` input from `nix-alien` with the normal `nix-index` if you want to use your local database.
