### PR TITLE
Pin nixpkgs

### DIFF
--- a/checks.nix
+++ b/checks.nix
@@ -1,4 +1,5 @@
 { pkgs ? (import ./compat.nix).pkgs
+, self ? (import ./compat.nix).flake
 }:
 
 let
@@ -6,8 +7,10 @@ let
 in
 {
   nix-alien-ci = pkgs.callPackage ./nix-alien.nix {
-    inherit rev;
     ci = true;
+    inherit rev;
+    nix-index = self.inputs.nix-index-database.packages.${pkgs.system}.nix-index-with-db;
+    nixpkgs-input = self.inputs.nix-index-database.inputs.nixpkgs.sourceInfo;
   };
 
   nix-index-update-ci = pkgs.callPackage ./nix-index-update.nix { };

--- a/default.nix
+++ b/default.nix
@@ -11,6 +11,7 @@ in
   nix-alien = pkgs.callPackage ./nix-alien.nix {
     inherit rev;
     nix-index = self.inputs.nix-index-database.packages.${pkgs.system}.nix-index-with-db;
+    nixpkgs-src = self.inputs.nix-index-database.inputs.nixpkgs.sourceInfo;
   };
 
   # For backwards compat, may be removed in the future

--- a/flake.lock
+++ b/flake.lock
@@ -36,9 +36,7 @@
     },
     "nix-index-database": {
       "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1697340827,
@@ -55,6 +53,22 @@
       }
     },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1697723726,
+        "narHash": "sha256-SaTWPkI8a5xSHX/rrKzUe+/uVNy6zCGMXgoeMb7T9rg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "7c9cc5a6e5d38010801741ac830a3f8fd667a7a0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1697009197,
         "narHash": "sha256-viVRhBTFT8fPJTb1N3brQIpFZnttmwo3JVKNuWRVc3s=",
@@ -75,7 +89,7 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nix-index-database": "nix-index-database",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,10 +8,7 @@
     };
     flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nix-index-database = {
-      url = "github:Mic92/nix-index-database";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    nix-index-database.url = "github:Mic92/nix-index-database";
   };
 
   outputs = { self, nixpkgs, flake-utils, ... }:

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
           default = self.outputs.packages.${system}.nix-alien;
         };
 
-        checks = import ./checks.nix { inherit pkgs; };
+        checks = import ./checks.nix { inherit pkgs self; };
 
         apps =
           let
@@ -43,6 +43,6 @@
             nix-index-update = mkApp { drv = self.outputs.packages.${system}.nix-index-update; };
           };
 
-        devShells.default = import ./shell.nix { inherit pkgs; };
+        devShells.default = import ./shell.nix { inherit pkgs self; };
       }));
 }

--- a/nix-alien.nix
+++ b/nix-alien.nix
@@ -34,6 +34,8 @@ python3.pkgs.buildPythonApplication {
       --subst-var-by nixpkgsLastModifiedDate ${nixpkgs-src.lastModifiedDate} \
       --subst-var-by nixpkgsRev ${nixpkgs-src.rev} \
       --subst-var-by nixpkgsHash ${nixpkgs-src.narHash}
+    substituteInPlace nix_alien/fhs_env_flake.template.nix \
+      --subst-var-by nixpkgsRev ${nixpkgs-src.rev}
     substituteInPlace tests/test_fhs_env.py \
       --subst-var-by nixpkgsLastModifiedDate ${nixpkgs-src.lastModifiedDate} \
       --subst-var-by nixpkgsRev ${nixpkgs-src.rev} \
@@ -42,6 +44,8 @@ python3.pkgs.buildPythonApplication {
       --subst-var-by nixpkgsLastModifiedDate ${nixpkgs-src.lastModifiedDate} \
       --subst-var-by nixpkgsRev ${nixpkgs-src.rev} \
       --subst-var-by nixpkgsHash ${nixpkgs-src.narHash}
+    substituteInPlace nix_alien/nix_ld_flake.template.nix \
+      --subst-var-by nixpkgsRev ${nixpkgs-src.rev}
     substituteInPlace tests/test_nix_ld.py \
       --subst-var-by nixpkgsLastModifiedDate ${nixpkgs-src.lastModifiedDate} \
       --subst-var-by nixpkgsRev ${nixpkgs-src.rev} \

--- a/nix-alien.nix
+++ b/nix-alien.nix
@@ -31,23 +31,7 @@ python3.pkgs.buildPythonApplication {
 
   preBuild = lib.optionalString (rev != null) ''
     echo "__version__ = \"${rev}\"" > nix_alien/_version.py
-    substituteInPlace nix_alien/fhs_env.template.nix \
-      --subst-var-by nixpkgsLastModifiedDate ${nixpkgs-src.lastModifiedDate} \
-      --subst-var-by nixpkgsRev ${nixpkgs-src.rev} \
-      --subst-var-by nixpkgsHash ${nixpkgs-src.narHash}
-    substituteInPlace nix_alien/fhs_env_flake.template.nix \
-      --subst-var-by nixpkgsRev ${nixpkgs-src.rev}
-    substituteInPlace tests/test_fhs_env.py \
-      --subst-var-by nixpkgsLastModifiedDate ${nixpkgs-src.lastModifiedDate} \
-      --subst-var-by nixpkgsRev ${nixpkgs-src.rev} \
-      --subst-var-by nixpkgsHash ${nixpkgs-src.narHash}
-    substituteInPlace nix_alien/nix_ld.template.nix \
-      --subst-var-by nixpkgsLastModifiedDate ${nixpkgs-src.lastModifiedDate} \
-      --subst-var-by nixpkgsRev ${nixpkgs-src.rev} \
-      --subst-var-by nixpkgsHash ${nixpkgs-src.narHash}
-    substituteInPlace nix_alien/nix_ld_flake.template.nix \
-      --subst-var-by nixpkgsRev ${nixpkgs-src.rev}
-    substituteInPlace tests/test_nix_ld.py \
+    substituteInPlace {nix_alien,tests}/*.{py,nix} \
       --subst-var-by nixpkgsLastModifiedDate ${nixpkgs-src.lastModifiedDate} \
       --subst-var-by nixpkgsRev ${nixpkgs-src.rev} \
       --subst-var-by nixpkgsHash ${nixpkgs-src.narHash}

--- a/nix-alien.nix
+++ b/nix-alien.nix
@@ -1,15 +1,16 @@
 { lib
 , fzf
 , nix-index
-, nixpkgs-src
+, nixpkgs-src ? {
+    lastModifiedDate = "19700101000000";
+    rev = "nixpkgs-unstable";
+    narHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+  }
 , python3
-, ruff
 , rev ? null
 , dev ? false
-, ci ? false
 }:
 
-assert dev -> !ci;
 let
   version = if (rev != null) then rev else "dev";
   deps = (lib.importTOML ./pyproject.toml).project.dependencies;
@@ -56,18 +57,7 @@ python3.pkgs.buildPythonApplication {
 
   nativeCheckInputs = with python3.pkgs; [
     pytestCheckHook
-  ] ++ lib.optionals ci [
-    black
-    mypy
-    ruff
   ];
-
-  preCheck = lib.optionalString ci ''
-    export PYLINTHOME="$(mktemp -d)"
-    black --check ./nix_alien
-    mypy --ignore-missing-imports ./nix_alien
-    ruff check ./nix_alien
-  '';
 
   meta = with lib; {
     description = "Run unpatched binaries on Nix/NixOS";

--- a/nix-alien.nix
+++ b/nix-alien.nix
@@ -1,6 +1,7 @@
 { lib
 , fzf
 , nix-index
+, nixpkgs-src
 , python3
 , ruff
 , rev ? null
@@ -29,6 +30,22 @@ python3.pkgs.buildPythonApplication {
 
   preBuild = lib.optionalString (rev != null) ''
     echo "__version__ = \"${rev}\"" > nix_alien/_version.py
+    substituteInPlace nix_alien/fhs_env.template.nix \
+      --subst-var-by nixpkgsLastModifiedDate ${nixpkgs-src.lastModifiedDate} \
+      --subst-var-by nixpkgsRev ${nixpkgs-src.rev} \
+      --subst-var-by nixpkgsHash ${nixpkgs-src.narHash}
+    substituteInPlace tests/test_fhs_env.py \
+      --subst-var-by nixpkgsLastModifiedDate ${nixpkgs-src.lastModifiedDate} \
+      --subst-var-by nixpkgsRev ${nixpkgs-src.rev} \
+      --subst-var-by nixpkgsHash ${nixpkgs-src.narHash}
+    substituteInPlace nix_alien/nix_ld.template.nix \
+      --subst-var-by nixpkgsLastModifiedDate ${nixpkgs-src.lastModifiedDate} \
+      --subst-var-by nixpkgsRev ${nixpkgs-src.rev} \
+      --subst-var-by nixpkgsHash ${nixpkgs-src.narHash}
+    substituteInPlace tests/test_nix_ld.py \
+      --subst-var-by nixpkgsLastModifiedDate ${nixpkgs-src.lastModifiedDate} \
+      --subst-var-by nixpkgsRev ${nixpkgs-src.rev} \
+      --subst-var-by nixpkgsHash ${nixpkgs-src.narHash}
   '';
 
   doCheck = !dev;

--- a/nix_alien/fhs_env.template.nix
+++ b/nix_alien/fhs_env.template.nix
@@ -1,4 +1,11 @@
-{ pkgs ? import <nixpkgs> { } }:
+{ pkgs ? import
+    (builtins.fetchTarball {
+      name = "nixpkgs-unstable-@nixpkgsLastModifiedDate@";
+      url = "https://github.com/NixOS/nixpkgs/archive/@nixpkgsRev@.tar.gz";
+      sha256 = "@nixpkgsHash@";
+    })
+    { }
+}:
 
 let
   inherit (pkgs) buildFHSUserEnv;

--- a/nix_alien/fhs_env_flake.template.nix
+++ b/nix_alien/fhs_env_flake.template.nix
@@ -1,7 +1,7 @@
 {
   description = "${__name__}-fhs";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/@nixpkgsRev@";
 
   outputs = { self, nixpkgs }:
     let
@@ -23,7 +23,7 @@
 
       defaultApp.${system} = {
         type = "app";
-        program = "${defaultPackage.${system}}/bin/${__name__}-fhs";
+        program = "${self.outputs.defaultPackage.${system}}/bin/${__name__}-fhs";
       };
     };
 }

--- a/nix_alien/helpers.py
+++ b/nix_alien/helpers.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from string import Template
 from typing import Callable, Optional
 
-UUID_NAMESPACE = uuid.UUID("f318d4a6-dd46-47ce-995d-e95c17cadcc0")
+UUID_NAMESPACE = uuid.UUID("eebf3397-2041-4370-bf33-937b33d5c959")
 
 
 def edit_file(file: Path) -> subprocess.CompletedProcess:

--- a/nix_alien/nix_ld.template.nix
+++ b/nix_alien/nix_ld.template.nix
@@ -1,4 +1,11 @@
-{ pkgs ? import <nixpkgs> { } }:
+{ pkgs ? import
+    (builtins.fetchTarball {
+      name = "nixpkgs-unstable-@nixpkgsLastModifiedDate@";
+      url = "https://github.com/NixOS/nixpkgs/archive/@nixpkgsRev@.tar.gz";
+      sha256 = "@nixpkgsHash@";
+    })
+    { }
+}:
 
 let
   inherit (pkgs) lib stdenv;

--- a/nix_alien/nix_ld_flake.template.nix
+++ b/nix_alien/nix_ld_flake.template.nix
@@ -1,7 +1,7 @@
 {
   description = "${__name__}-nix-ld";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/@nixpkgsRev@";
 
   outputs = { self, nixpkgs }:
     let
@@ -15,11 +15,10 @@
           NIX_LD_LIBRARY_PATH = with pkgs; lib.makeLibraryPath [
             ${__packages__}
           ];
-          NIX_LD = lib.fileContents "${stdenv.cc}/nix-support/dynamic-linker";
         in
         pkgs.writeShellScriptBin "${__name__}" ''
           export NIX_LD_LIBRARY_PATH='${NIX_LD_LIBRARY_PATH}'${"\${NIX_LD_LIBRARY_PATH:+':'}$NIX_LD_LIBRARY_PATH"}
-          export NIX_LD='${NIX_LD}'
+          export NIX_LD="$(cat ${stdenv.cc}/nix-support/dynamic-linker)"
           ${__program__} "$@"
         '';
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,14 @@
-{ pkgs ? (import ./compat.nix).pkgs }:
+{ pkgs ? (import ./compat.nix).pkgs
+, self ? (import ./compat.nix).flake
+}:
 
 let
   inherit (pkgs) python3 callPackage;
-  nix-alien = python3.pkgs.toPythonModule (callPackage ./nix-alien.nix { dev = true; });
+  nix-alien = python3.pkgs.toPythonModule (callPackage ./nix-alien.nix {
+    dev = true;
+    nix-index = self.inputs.nix-index-database.packages.${pkgs.system}.nix-index-with-db;
+    nixpkgs-src = self.inputs.nix-index-database.inputs.nixpkgs.sourceInfo;
+  });
   python-with-packages = python3.withPackages (ps: with ps; [
     black
     mypy

--- a/tests/test_fhs_env.py
+++ b/tests/test_fhs_env.py
@@ -95,7 +95,7 @@ def test_create_fhs_env_drv_flake(mock_machine, mock_find_libs, pytestconfig):
 {
   description = "xyz-fhs";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/@nixpkgsRev@";
 
   outputs = { self, nixpkgs }:
     let
@@ -120,7 +120,7 @@ def test_create_fhs_env_drv_flake(mock_machine, mock_find_libs, pytestconfig):
 
       defaultApp.${system} = {
         type = "app";
-        program = "${defaultPackage.${system}}/bin/xyz-fhs";
+        program = "${self.outputs.defaultPackage.${system}}/bin/xyz-fhs";
       };
     };
 }

--- a/tests/test_fhs_env.py
+++ b/tests/test_fhs_env.py
@@ -14,7 +14,14 @@ def test_create_fhs_env_drv(mock_find_libs, pytestconfig):
     assert (
         fhs_env.create_fhs_env_drv("xyz", additional_packages=["libGL"])
         == """\
-{ pkgs ? import <nixpkgs> { } }:
+{ pkgs ? import
+    (builtins.fetchTarball {
+      name = "nixpkgs-unstable-@nixpkgsLastModifiedDate@";
+      url = "https://github.com/NixOS/nixpkgs/archive/@nixpkgsRev@.tar.gz";
+      sha256 = "@nixpkgsHash@";
+    })
+    { }
+}:
 
 let
   inherit (pkgs) buildFHSUserEnv;
@@ -45,7 +52,14 @@ def test_create_fhs_env_drv_with_spaces(mock_find_libs, pytestconfig):
     assert (
         fhs_env.create_fhs_env_drv("x y z", additional_packages=["libGL"])
         == """\
-{ pkgs ? import <nixpkgs> { } }:
+{ pkgs ? import
+    (builtins.fetchTarball {
+      name = "nixpkgs-unstable-@nixpkgsLastModifiedDate@";
+      url = "https://github.com/NixOS/nixpkgs/archive/@nixpkgsRev@.tar.gz";
+      sha256 = "@nixpkgsHash@";
+    })
+    { }
+}:
 
 let
   inherit (pkgs) buildFHSUserEnv;

--- a/tests/test_fhs_env.py
+++ b/tests/test_fhs_env.py
@@ -236,7 +236,7 @@ def test_main_with_print(monkeypatch, capsys):
     assert (
         out
         == """\
-/home/nameless-shelter/.cache/nix-alien/b5ae45f6-276c-53a3-93ab-4a44f35976a4/fhs-env/default.nix
+/home/nameless-shelter/.cache/nix-alien/d51a223b-43f0-56c6-b5c8-2404823026ac/fhs-env/default.nix
 """
     )
 
@@ -246,6 +246,6 @@ def test_main_with_print(monkeypatch, capsys):
     assert (
         out
         == """\
-/home/nameless-shelter/.cache/nix-alien/b5ae45f6-276c-53a3-93ab-4a44f35976a4/fhs-env/flake.nix
+/home/nameless-shelter/.cache/nix-alien/d51a223b-43f0-56c6-b5c8-2404823026ac/fhs-env/flake.nix
 """
     )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -12,31 +12,31 @@ def test_edit_file(monkeypatch):
 def test_get_hash_for_program(monkeypatch):
     monkeypatch.setenv("HOME", "/home/nameless-shelter")
     assert helpers.get_hash_for_program("/home/nameless-shelter/abc") == UUID(
-        "d0efaea7-176f-56e6-99a0-ea49599a163b"
+        "0acc4435-07de-59bf-a1c3-a42f55aaca35"
     )
     assert helpers.get_hash_for_program("~/abc") == UUID(
-        "d0efaea7-176f-56e6-99a0-ea49599a163b"
+        "0acc4435-07de-59bf-a1c3-a42f55aaca35"
     )
     assert helpers.get_hash_for_program("/abc") == UUID(
-        "f52177f5-def5-5d9e-91fc-ef1283fc54b1"
+        "cf2f97e0-6eec-5407-aea0-bbecc488d451"
     )
     assert helpers.get_hash_for_program("/./abc") == UUID(
-        "f52177f5-def5-5d9e-91fc-ef1283fc54b1"
+        "cf2f97e0-6eec-5407-aea0-bbecc488d451"
     )
     assert helpers.get_hash_for_program("/xyz/../abc") == UUID(
-        "f52177f5-def5-5d9e-91fc-ef1283fc54b1"
+        "cf2f97e0-6eec-5407-aea0-bbecc488d451"
     )
 
 
 def test_get_cache_path(monkeypatch):
     monkeypatch.setenv("HOME", "/home/nameless-shelter")
     assert helpers.get_cache_path("/abc") == Path(
-        "/home/nameless-shelter/.cache/nix-alien/f52177f5-def5-5d9e-91fc-ef1283fc54b1"
+        "/home/nameless-shelter/.cache/nix-alien/cf2f97e0-6eec-5407-aea0-bbecc488d451"
     )
 
     monkeypatch.setenv("XDG_CACHE_HOME", "/")
     assert helpers.get_cache_path("/abc") == Path(
-        "/nix-alien/f52177f5-def5-5d9e-91fc-ef1283fc54b1"
+        "/nix-alien/cf2f97e0-6eec-5407-aea0-bbecc488d451"
     )
 
 
@@ -48,7 +48,7 @@ def test_get_dest_path(monkeypatch):
         directory="bar",
         filename="foo.nix",
     ) == Path(
-        "/home/nameless-shelter/.cache/nix-alien/f52177f5-def5-5d9e-91fc-ef1283fc54b1/bar/foo.nix"
+        "/home/nameless-shelter/.cache/nix-alien/cf2f97e0-6eec-5407-aea0-bbecc488d451/bar/foo.nix"
     )
 
     monkeypatch.setenv("XDG_CACHE_HOME", "/")
@@ -57,7 +57,7 @@ def test_get_dest_path(monkeypatch):
         program="/abc",
         directory="bar",
         filename="foo.nix",
-    ) == Path("/nix-alien/f52177f5-def5-5d9e-91fc-ef1283fc54b1/bar/foo.nix")
+    ) == Path("/nix-alien/cf2f97e0-6eec-5407-aea0-bbecc488d451/bar/foo.nix")
 
     assert helpers.get_dest_path(
         destination="/quux",

--- a/tests/test_nix_ld.py
+++ b/tests/test_nix_ld.py
@@ -14,7 +14,14 @@ def test_create_nix_ld_drv(mock_find_libs, pytestconfig):
     assert (
         nix_ld.create_nix_ld_drv("xyz", additional_packages=["libGL"])
         == """\
-{ pkgs ? import <nixpkgs> { } }:
+{ pkgs ? import
+    (builtins.fetchTarball {
+      name = "nixpkgs-unstable-@nixpkgsLastModifiedDate@";
+      url = "https://github.com/NixOS/nixpkgs/archive/@nixpkgsRev@.tar.gz";
+      sha256 = "@nixpkgsHash@";
+    })
+    { }
+}:
 
 let
   inherit (pkgs) lib stdenv;
@@ -47,7 +54,14 @@ def test_create_nix_ld_drv_with_spaces(mock_find_libs, pytestconfig):
     assert (
         nix_ld.create_nix_ld_drv("x y z", additional_packages=["libGL"])
         == """\
-{ pkgs ? import <nixpkgs> { } }:
+{ pkgs ? import
+    (builtins.fetchTarball {
+      name = "nixpkgs-unstable-@nixpkgsLastModifiedDate@";
+      url = "https://github.com/NixOS/nixpkgs/archive/@nixpkgsRev@.tar.gz";
+      sha256 = "@nixpkgsHash@";
+    })
+    { }
+}:
 
 let
   inherit (pkgs) lib stdenv;

--- a/tests/test_nix_ld.py
+++ b/tests/test_nix_ld.py
@@ -241,7 +241,7 @@ def test_main_with_print(monkeypatch, capsys):
     assert (
         out
         == """\
-/home/nameless-shelter/.cache/nix-alien/b5ae45f6-276c-53a3-93ab-4a44f35976a4/nix-ld/default.nix
+/home/nameless-shelter/.cache/nix-alien/d51a223b-43f0-56c6-b5c8-2404823026ac/nix-ld/default.nix
 """
     )
 
@@ -251,6 +251,6 @@ def test_main_with_print(monkeypatch, capsys):
     assert (
         out
         == """\
-/home/nameless-shelter/.cache/nix-alien/b5ae45f6-276c-53a3-93ab-4a44f35976a4/nix-ld/flake.nix
+/home/nameless-shelter/.cache/nix-alien/d51a223b-43f0-56c6-b5c8-2404823026ac/nix-ld/flake.nix
 """
     )

--- a/tests/test_nix_ld.py
+++ b/tests/test_nix_ld.py
@@ -99,7 +99,7 @@ def test_create_nix_ld_drv_flake(mock_machine, mock_find_libs, pytestconfig):
 {
   description = "xyz-nix-ld";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/@nixpkgsRev@";
 
   outputs = { self, nixpkgs }:
     let
@@ -116,11 +116,10 @@ def test_create_nix_ld_drv_flake(mock_machine, mock_find_libs, pytestconfig):
             quux.out
             libGL
           ];
-          NIX_LD = lib.fileContents "${stdenv.cc}/nix-support/dynamic-linker";
         in
         pkgs.writeShellScriptBin "xyz" ''
           export NIX_LD_LIBRARY_PATH='${NIX_LD_LIBRARY_PATH}'${"\\${NIX_LD_LIBRARY_PATH:+':'}$NIX_LD_LIBRARY_PATH"}
-          export NIX_LD='${NIX_LD}'
+          export NIX_LD="$(cat ${stdenv.cc}/nix-support/dynamic-linker)"
           %s/xyz "$@"
         '';
 


### PR DESCRIPTION
This PR will pin `nixpkgs` in the generated `default.nix` files by extracting the repository information from nix-index-database's Flake metadata.

This should ensure that whatever package we find using `nix-index` will match the output files and make it just work(TM), avoiding issues where the user has a different `<nixpkgs>` set in their channels and the shell failing with errors because it can't find the specified package.

Fix https://github.com/thiagokokada/nix-alien/issues/87.