### PR TITLE
speed up dependency resolver

### DIFF
--- a/nix_alien/libs.py
+++ b/nix_alien/libs.py
@@ -53,7 +53,7 @@ def find_libs(
     resolved_deps: dict[str, Optional[str]] = {}
 
     for dep in deps:
-        if not dep.soname or dep.found:
+        if not dep.soname or dep.found or dep.soname in resolved_deps:
             continue
 
         candidates = find_lib_candidates(dep.soname)


### PR DESCRIPTION
I need to use an executable quite often, where nix-alien normally takes 3.5 Minutes to find all the libs.

I've short-circuited the resolver, if it already has the library resolved.

I also removed the one short circuit, which existed to not show the user selection prompt multiple times for the same library, as this check becomes unneeded.

This reduced the time for this executable to 30s, as it won't execute the nix-index command multiple times for the same library.
